### PR TITLE
fix: Fix the bug that the timeout will not be cleared when the compon…

### DIFF
--- a/packages/tuya-panel-gateway-sdk/src/components/addProgress/index.tsx
+++ b/packages/tuya-panel-gateway-sdk/src/components/addProgress/index.tsx
@@ -54,9 +54,9 @@ const AddProgress: FC<AddProgressProps> = ({
 
   // 监听进度，如果已添加数和待添加总数相同，则触发完成事件，否则刷新倒计时。
   useEffect(() => {
+    clearTimeout(timer);
     if (progress !== total) {
       if (!isCustomProgressChange) {
-        clearTimeout(timer);
         countdown();
       }
     } else if (typeof onFinish === 'function') {


### PR DESCRIPTION
…ent 'AddProgress' onFinished triggered

## Owner

- [ ] Nickname(Tuya): 钟离
- [ ] Intra-group review（组内审阅人员）：无

## Description

Fix the bug that the timeout will not be cleared when the component 'AddProgress' onFinished triggered.

## Package

Please select the relevant package.

- [ ] tuya-panel-animation-sdk
- [ ] tuya-panel-api
- [ ] tuya-panel-electrician-sdk
- [ ] tuya-panel-ipc-sdk
- [ ] tuya-panel-lamp-sdk
- [ ] tuya-panel-lock-sdk
- [ ] tuya-panel-robot-sdk
- [ ] tuya-panel-outdoor-sdk
- [x] tuya-panel-gateway-sdk

## Type of change

Please select the relevant option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Self CheckList

Please check all options.

- [ ] Intra-group review
- [x] ESLint lint
- [x] Example Run
- [x] Jest Run
- [x] No Grammer Error
- [x] No Spell Error
- [x] No Merge Conflict
